### PR TITLE
skip [net] tests on CI

### DIFF
--- a/testdata/network_conditions.txt
+++ b/testdata/network_conditions.txt
@@ -1,5 +1,7 @@
 # Test network condition support
 
+[env:CI] skip Skipping this test on GitHub Actions
+
 # This command will only run if network is available
 [net] exec echo "Network is available"
 


### PR DESCRIPTION
I'm hoping this will also mean these get skipped when the Copilot agent iterates, since it trips a firewall rule and results in comment spam: https://github.com/imjasonh/testscript-rs/pull/27#issuecomment-3350186075